### PR TITLE
Move setting of NODE_ENV to inside testTasks function.

### DIFF
--- a/src/gulp-tasks-test.js
+++ b/src/gulp-tasks-test.js
@@ -6,11 +6,11 @@ import tapSpec from 'tap-spec';
 
 import gulpOptionsBuilder from './gulp-options-builder';
 
-const envs = env.set({
-  NODE_ENV: 'test'
-});
-
 export function testTasks (gulp, opts) {
+
+  const envs = env.set({
+    NODE_ENV: 'test'
+  });
 
   const runSequence = require('run-sequence').use(gulp);
 


### PR DESCRIPTION
Move setting of NODE_ENV to inside testTasks function. 
Otherwise, it is being set to test when file is loaded.