### PR TITLE
Add devServer as possible config option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ grommet-toolbox will look into your application's root folder and extract the co
 | devServerHost | string | Optional. Host address for the webpack dev server | 'localhost' | `devServerHost: '127.0.0.1'` |
 | devServerPort | int | Optional. Sets a listener port for the webpack dev server | 8080 | `devServerPort: 9000` |
 | devServerProxy | object | Optional. Proxy requests from the webpack dev server | undefined | `devServerProxy: { '/rest/*': 'http://localhost:8114' }`|
+| devServer | object | Optional. Any additional options for the webpack dev server | undefined | `devServer: { https: true }`|
 | dist | string | Optional. Location of the distribution folder | 'dist' | `dist: 'distribution'` |
 | distPreprocess | array | Optional. A set of tasks to run before `gulp dist` | undefined | `['dist-css']` |
 | env | object | Optional. Adds environment variables for Node | undefined | `{ DEV_MODE: 'true'}` |

--- a/src/gulp-tasks-dev.js
+++ b/src/gulp-tasks-dev.js
@@ -4,6 +4,7 @@ const argv = yargs.argv;
 import WebpackDevServer from 'webpack-dev-server';
 import gulpOpen from 'gulp-open';
 import path from 'path';
+import deepAssign from 'deep-assign';
 
 import gulpOptionsBuilder from './gulp-options-builder';
 import gulpTasksCore from './gulp-tasks-core';
@@ -61,6 +62,10 @@ export function devTasks (gulp, opts) {
       devServerConfig.proxy = options.devServerProxy;
     }
 
+    if (options.devServer) {
+      deepAssign(devServerConfig, options.devServer);
+    }
+
     const server = new WebpackDevServer(
       webpack(config), devServerConfig
     );
@@ -103,10 +108,11 @@ export function devTasks (gulp, opts) {
       if (err) {
         console.error('[webpack-dev-server] failed to start:', err);
       } else {
+        const protocol = (options.devServer && options.devServer.https) ? 'https' : 'http';
         const openHost = (host === '0.0.0.0') ? 'localhost' : host;
         console.log('[webpack-dev-server] started: opening the app in your default browser...');
         const suffix = options.publicPath ? options.publicPath + '/' : '';
-        const openURL = 'http://' + openHost + ':' + options.devServerPort + '/webpack-dev-server/' + suffix;
+        const openURL = protocol + '://' + openHost + ':' + options.devServerPort + '/webpack-dev-server/' + suffix;
         gulp.src(path.join(options.dist, 'index.html'))
         .pipe(gulpOpen({
           uri: openURL


### PR DESCRIPTION
We need https for our secure authentication cookies to work. Added config to allow turning on https in dev mode.