### PR TITLE
add option for referencing custom eslintConfigPath in options

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,8 @@ grommet-toolbox will look into your application's root folder and extract the co
 | ------------- |---------------|-----------------|------------- |------------|
 | base          | string        | Optional. Base working directory           | process.cwd()      | `base: '.'` |
 | copyAssets    | array         | Optional. Assets to be copied to the distribution folder |  undefined  | [See copyAssets WIKI](https://github.com/grommet/grommet-toolbox/wiki/copyAssets-WIKI)  |
-| customEslintPath | string     | Optional. Path to your custom eslint overrides  | undefined          | `customEslintPath: path.resolve(__dirname, 'customEslintrc')`        |
+| eslintConfigPath | string     | Optional. Path to your custom eslint config file  | undefined          | `eslintConfigPath: path.resolve(__dirname, '../.eslintrc')`        |
+| eslintOverride | string     | Optional. Path to your custom eslint overrides  | undefined          | `eslintOverride: path.resolve(__dirname, 'customEslintrc')`        |
 | devPreprocess | array | Optional. A set of tasks to run before `gulp dev` | undefined | `['set-webpack-alias']` |
 | devServerDisableHot | boolean | Optional. If true, will disable webpack hot reloading | false | `devServerDisableHot: true` |
 | devServerHost | string | Optional. Host address for the webpack dev server | 'localhost' | `devServerHost: '127.0.0.1'` |

--- a/src/gulp-tasks-linters.js
+++ b/src/gulp-tasks-linters.js
@@ -17,15 +17,20 @@ export function linterTasks (gulp, opts) {
     scssLintPath = path.resolve(__dirname, '../.scss-lint.yml');
   }
 
-  let esLintPath = path.resolve(process.cwd(), '.eslintrc');
+  let esLintPath = options.eslintConfigPath || path.resolve(process.cwd(), '.eslintrc');
   try {
     fs.accessSync(esLintPath, fs.F_OK);
   } catch (e) {
     esLintPath = path.resolve(__dirname, '../.eslintrc');
   }
 
-  const customEslint = options.customEslintPath ?
-    require(options.customEslintPath) : {};
+  let eslintOverride = options.eslintOverride ? 
+    require(options.eslintOverride) : {};
+
+  if (options.customEslintPath) {
+    eslintOverride = require(options.customEslintPath);
+    console.warn('customEslintPath has been deprecated. You should use eslintOverride instead');
+  }
 
   gulp.task('scsslint', () => {
     if (options.scsslint) {
@@ -47,7 +52,7 @@ export function linterTasks (gulp, opts) {
   gulp.task('jslint', () => {
     const eslintRules = deepAssign({
       configFile: esLintPath
-    }, customEslint);
+    }, eslintOverride);
     return gulp.src(options.jsAssets || [])
       .pipe(eslint(eslintRules))
       .pipe(eslint.formatEach())


### PR DESCRIPTION
also deprecates `customEslintPath` option in favor of `eslintOverride`