### PR TITLE
Added missing dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
     "tarball-extract": "0.0.3",
     "webpack": "^1.12.14",
     "webpack-dev-server": "^1.14.1",
-    "webpack-stream": "^3.1.0"
+    "webpack-stream": "^3.1.0",
+    "yargs": "^3.32.0"
   },
   "scripts": {
     "build": "node_modules/.bin/babel src --out-dir lib --copy-files --loose-mode"


### PR DESCRIPTION
I am not confident in my npm-fu, but it seems like since you are directly using yargs in this repo, it should be a direct dependency.  Currently it is an indirect dependency because some of your dependencies have it as a dependency but it seems fragile to rely on that and possibly broken in some cases.

The reason this came up is that when I was trying to automate my grommet ui build, it failed with the following error:

```
module.js:327
    throw err;
    ^

Error: Cannot find module 'yargs'
    at Function.Module._resolveFilename (module.js:325:15)
    at Function.Module._load (module.js:276:25)
    at Module.require (module.js:353:17)
    at require (internal/module.js:12:17)
    at Object.<anonymous> (/opt/mount1/home/jenkins/workspace/SFRM-Demo-develop/Grommet-UI-Demo/node_modules/grommet-toolbox/lib/gulp-tasks-dev.js:12:14)
    at Module._compile (module.js:409:26)
    at Module._extensions..js (module.js:416:10)
    at Object.require.extensions.(anonymous function) [as .js] (/opt/mount1/home/jenkins/workspace/SFRM-Demo-develop/Grommet-UI-Demo/node_modules/babel-core/node_modules/babel-register/lib/node.js:166:7)
    at Module.load (module.js:343:32)
    at Function.Module._load (module.js:300:12)
Build step 'Execute shell' marked build as failure
Archiving artifacts
Finished: FAILURE
```

I cannot reproduce the error locally and so am not sure how to test this fix, but thought this might be goodness anyways.

Sorry for the super long-winded pull request description for a one line change!