### PR TITLE
Add profile config opt

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ grommet-toolbox will look into your application's root folder and extract the co
 | sync | object | Optional. Syncs your content to a remote server | undefined | `sync: { hostname: 'grommet.io', username: 'grommet', remoteDestination: '/var/www/html/'}` |
 | testPaths | array | Optional. Location of your test assets | undefined | `testPaths: ['test/**/*.js']` |
 | webpack | object | Optional. Additional webpack options to be used in gulp dist | undefined | [See Webpack Configuration](https://webpack.github.io/docs/configuration.html) |
+| webpackProfile | string | Optional. Location to save webpack profile stats in json format. | undefined | `webpackProfile: './stats.json'` |
 
 ### Example
 

--- a/src/gulp-tasks-dev.js
+++ b/src/gulp-tasks-dev.js
@@ -76,7 +76,7 @@ export function devTasks (gulp, opts) {
         const profileFile = path.resolve(options.webpackProfile);
         const statsString = JSON.stringify(stats.toJson());
         writeFile(profileFile, statsString, (err) => {
-          if (err) console.error('Failed to write webpackProfile:', err);
+          if (err) return console.error('Failed to write webpackProfile:', err);
           console.log('[webpack] Wrote webpack stats to:', profileFile);
           console.log('[webpack] Analyze stats at https://webpack.github.io/analyse/');
         });
@@ -84,7 +84,7 @@ export function devTasks (gulp, opts) {
     }
 
     const server = new WebpackDevServer(compiler, devServerConfig);
-    
+
     server.use('/', (req, res, next) => {
 
       const acceptLanguageHeader = req.headers['accept-language'];

--- a/src/gulp-tasks-dev.js
+++ b/src/gulp-tasks-dev.js
@@ -4,6 +4,7 @@ const argv = yargs.argv;
 import WebpackDevServer from 'webpack-dev-server';
 import gulpOpen from 'gulp-open';
 import path from 'path';
+import {writeFile} from 'fs';
 import deepAssign from 'deep-assign';
 
 import gulpOptionsBuilder from './gulp-options-builder';
@@ -45,7 +46,7 @@ export function devTasks (gulp, opts) {
 
     const devServerConfig = {
       contentBase: options.dist,
-      hot: options.devServerDisableHot ? false : true,
+      hot: !options.devServerDisableHot,
       inline: true,
       stats: {
         colors: true
@@ -66,9 +67,24 @@ export function devTasks (gulp, opts) {
       deepAssign(devServerConfig, options.devServer);
     }
 
-    const server = new WebpackDevServer(
-      webpack(config), devServerConfig
-    );
+    if (options.webpackProfile) config.profile = true;
+
+    const compiler = webpack(config);
+
+    if (options.webpackProfile) {
+      compiler.plugin('done', stats => {
+        const profileFile = path.resolve(options.webpackProfile);
+        const statsString = JSON.stringify(stats.toJson());
+        writeFile(profileFile, statsString, (err) => {
+          if (err) console.error('Failed to write webpackProfile:', err);
+          console.log('[webpack] Wrote webpack stats to:', profileFile);
+          console.log('[webpack] Analyze stats at https://webpack.github.io/analyse/');
+        });
+      });
+    }
+
+    const server = new WebpackDevServer(compiler, devServerConfig);
+    
     server.use('/', (req, res, next) => {
 
       const acceptLanguageHeader = req.headers['accept-language'];


### PR DESCRIPTION
Adds a config option that enables profiling in webpack when running `gulp dev`. The resultant json stats are then saved to this location for analysis on tools like https://webpack.github.io/analyse/.