### PR TITLE
Fix https on webpack-dev-server

### DIFF
--- a/src/webpack.dev.config.js
+++ b/src/webpack.dev.config.js
@@ -13,9 +13,10 @@ const env = deepAssign({}, options.env, {
 });
 
 delete options.webpack.entry;
+const protocol = (options.devServer && options.devServer.https) ? 'https' : 'http';
 const config = deepAssign({
   entry: [
-    'webpack-dev-server/client/index.js?http://' + (options.devServerHost || 'localhost') + ':' + (options.devServerPort || '8080'),
+    'webpack-dev-server/client/index.js?' + protocol + '://' + (options.devServerHost || 'localhost') + ':' + (options.devServerPort || '8080'),
     'webpack/hot/dev-server',
     './' + options.mainJs
   ],


### PR DESCRIPTION
The webpack dev server websocket connection fails because it is trying to communicate over http and chrome is disallowing mixed protocol communication with the backend.  The failure is doubly annoying because it retries endlessly and litters the browser console with error messages.