### PR TITLE
add webpackDashboard option to toolbox config

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ grommet-toolbox will look into your application's root folder and extract the co
 | testPaths | array | Optional. Location of your test assets | undefined | `testPaths: ['test/**/*.js']` |
 | webpack | object | Optional. Additional webpack options to be used in gulp dist | undefined | [See Webpack Configuration](https://webpack.github.io/docs/configuration.html) |
 | webpackProfile | string | Optional. Location to save webpack profile stats in json format. | undefined | `webpackProfile: './stats.json'` |
+| webpackDashboard | boolean\|object | Optional. Render webpack output as dashboard summary (via [Webpack Dashboard](https://github.com/FormidableLabs/webpack-dashboard)). If object is passed, it is used as the config settings for the dashboard | undefined | `webpackDashboard: { minimal: true } |
 
 ### Example
 

--- a/package.json
+++ b/package.json
@@ -66,5 +66,8 @@
   },
   "scripts": {
     "build": "node_modules/.bin/babel src --out-dir lib --copy-files --loose-mode"
+  },
+  "devDependencies": {
+    "webpack-dashboard": "^0.1.6"
   }
 }

--- a/src/gulp-tasks-dev.js
+++ b/src/gulp-tasks-dev.js
@@ -47,6 +47,7 @@ export function devTasks (gulp, opts) {
     const devServerConfig = {
       contentBase: options.dist,
       hot: !options.devServerDisableHot,
+      quiet: options.webpackDashboard,
       inline: true,
       stats: {
         colors: true

--- a/src/webpack.dev.config.js
+++ b/src/webpack.dev.config.js
@@ -5,6 +5,10 @@ import deepAssign from 'deep-assign';
 import unique from './utils/unique';
 
 import gulpOptionsBuilder from './gulp-options-builder';
+
+import Dashboard from 'webpack-dashboard';
+import DashboardPlugin from 'webpack-dashboard/plugin';
+
 const options = gulpOptionsBuilder();
 
 const env = deepAssign({}, options.env, {
@@ -51,6 +55,12 @@ config.plugins = [
   new webpack.HotModuleReplacementPlugin(),
   new webpack.DefinePlugin(env)
 ];
+
+if (options.webpackDashboard) {
+
+  const dashboard = new Dashboard(Object(options.webpackDashboard));
+  config.plugins.push(new DashboardPlugin(dashboard.setData));
+}
 
 if (options.webpack.plugins) {
   options.webpack.plugins.forEach((plugin) =>


### PR DESCRIPTION
I find the output of [Webpack Dashboard](https://github.com/FormidableLabs/webpack-dashboard) to be a much more useful summary than the default output of Webpack. I think it'd be useful as a flag to set in the config for others to use. 

This adds a `webpackDashboard` option to the grommet-toolbox config enable the dashboard view:

![image](https://cloud.githubusercontent.com/assets/4998403/17864039/83dbd79c-6859-11e6-9291-fff599ed7bd3.png)
 Thanks @michaelgilley for the config assistance!
