### PR TITLE
Make sure that eslint ruleset can invalidate cache on update

### DIFF
--- a/src/gulp-tasks-linters.js
+++ b/src/gulp-tasks-linters.js
@@ -53,7 +53,10 @@ export function linterTasks (gulp, opts) {
     let jslintPipe = eslint(eslintRules);
 
     if (options.lintCache) {
+      const eslintRuleSet = fs.readFileSync(eslintRules.configFile, 'utf8');
+
       jslintPipe = cache(jslintPipe, {
+        key: (file) => eslintRuleSet + file.contents.toString('utf8'),
         success: (linted) => linted.eslint && !linted.eslint.messages.length,
         value: (linted) => ({eslint: linted.eslint})
       });


### PR DESCRIPTION
This ensures that jslint cache is refreshed when rules in the eslint config are updated or an eslint override file is used.