### PR TITLE
Consolidate args with options builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ grommet-toolbox will look into your application's root folder and extract the co
 
 | property      | type          | description     | default      | example    |
 | ------------- |---------------|-----------------|------------- |------------|
+| argv          | object        | Optional. Default cli args set on gulp tasks. *See above.* | `{}` | `{open: false}` |
 | base          | string        | Optional. Base working directory           | process.cwd()      | `base: '.'` |
 | copyAssets    | array         | Optional. Assets to be copied to the distribution folder |  undefined  | [See copyAssets WIKI](https://github.com/grommet/grommet-toolbox/wiki/copyAssets-WIKI)  |
 | eslintConfigPath | string     | Optional. Path to your custom eslint config file  | undefined          | `eslintConfigPath: path.resolve(__dirname, '../.eslintrc')`        |

--- a/README.md
+++ b/README.md
@@ -54,9 +54,12 @@ Grommet-toolbox augments gulp object with these additional tasks:
 * **gulp jslint**: uses `jsAssets` and `testPaths` options to lint your JavaScript code.
 * **gulp dev**: starts a webpack dev server with hot reloading. See options for example configuration.
   * `--config`: Set the path of the config file to use.
-  * `--skip-preprocess`: Skips preprocess tasks.
-  * `--skip-open`: Skips opening dev server url in a browser.
+  * `--no-preprocess`: Skips preprocess tasks.
+  * `--no-open`: Skips opening dev server url in a browser.
 * **gulp dist**: prepares your application/library for production.
+  * `--config`: Set the path of the config file to use.
+  * `--no-preprocess`: Skips preprocess tasks.
+  * `--no-minify`: Skips minifying JS code.
 * **gulp sync**: uses `sync` option to sync distribution content to a remote server.
 * **gulp test**: uses `testPaths` option to execute tests based on Tape.
 * **gulp test:watch**: runs tests and watch for changes to execute the tests again.

--- a/src/gulp-options-builder.js
+++ b/src/gulp-options-builder.js
@@ -1,6 +1,26 @@
 import path from 'path';
 import fs from 'fs';
 import deepAssign from 'deep-assign';
+import yargs from 'yargs';
+
+const argv = yargs
+  .option('minify', {
+    type: 'boolean',
+    default: true
+  })
+  .option('open', {
+    type: 'boolean',
+    default: true
+  })
+  .option('preprocess', {
+    type: 'boolean',
+    default: true
+  })
+  .argv;
+
+const deprecated = (name, warning) => {
+  console.warn(`[grommet-toolbox] DEPRECATED: ${name}. ${warning}`);
+};
 
 let options;
 export function getOptions (opts) {
@@ -96,6 +116,24 @@ export function getOptions (opts) {
         loader: 'style-loader!css-loader'
       }
     );
+
+    // Argv Deprecation warnings
+    if (argv.skipPreprocess) {
+      deprecated('skipPreprocess', 'Use --no-preprocess instead.');
+      argv.preprocess = false;
+    }
+
+    if (argv.skipOpen) {
+      deprecated('skipOpen', 'Use --no-open instead.');
+      argv.open = false;
+    }
+
+    if (argv.skipMinify) {
+      deprecated('skipMinify', 'Use --no-minify instead.');
+      argv.minify = false;
+    }
+
+    options.argv = deepAssign({}, options.argv, argv);
   }
 
   return options;

--- a/src/gulp-tasks-dev.js
+++ b/src/gulp-tasks-dev.js
@@ -1,6 +1,4 @@
 import webpack from 'webpack';
-import yargs from 'yargs';
-const argv = yargs.argv;
 import WebpackDevServer from 'webpack-dev-server';
 import gulpOpen from 'gulp-open';
 import path from 'path';
@@ -19,9 +17,12 @@ export function devTasks (gulp, opts) {
   const options = gulpOptionsBuilder(opts);
 
   gulp.task('dev-preprocess', (callback) => {
-    if (argv.skipPreprocess) {
+    if (!options.argv.preprocess) {
       callback();
-    } else if (options.devPreprocess) {
+      return;
+    }
+
+    if (options.devPreprocess) {
       runSequence(
         'clean', 'generate-icons', options.devPreprocess, 'copy', callback
       );
@@ -36,8 +37,8 @@ export function devTasks (gulp, opts) {
       __dirname, 'webpack.dev.config.js'
     );
 
-    if (argv.config) {
-      webpackConfigPath = path.resolve(argv.config);
+    if (options.argv.config) {
+      webpackConfigPath = path.resolve(options.argv.config);
     }
 
     const config = require(webpackConfigPath);
@@ -128,14 +129,14 @@ export function devTasks (gulp, opts) {
         const openURL = protocol + '://' + openHost + ':' + options.devServerPort + suffix;
 
         let openMsg = '[webpack-dev-server] started: ';
-        if (argv.skipOpen) {
+        if (!options.argv.open) {
           openMsg += `app available at location: \u001b[33m${openURL}\u001b[39m`;
         } else {
           openMsg += 'opening the app in your default browser...';
         }
 
         console.log(openMsg);
-        if (argv.skipOpen) return;
+        if (!options.argv.open) return;
 
         gulp.src(__filename)
         .pipe(gulpOpen({

--- a/src/gulp-tasks-dist.js
+++ b/src/gulp-tasks-dist.js
@@ -1,7 +1,5 @@
 import gulpWebpack from 'webpack-stream';
 import path from 'path';
-import yargs from 'yargs';
-const argv = yargs.argv;
 
 import gulpOptionsBuilder from './gulp-options-builder';
 import gulpTasksCore from './gulp-tasks-core';
@@ -19,9 +17,12 @@ export function distTasks (gulp, opts) {
   const options = gulpOptionsBuilder(opts);
 
   gulp.task('dist-preprocess', (callback) => {
-    if (argv.skipPreprocess) {
+    if (!options.argv.preprocess) {
       callback();
-    } else if (options.distPreprocess) {
+      return;
+    }
+
+    if (options.distPreprocess) {
       if (process.env.CI) {
         runSequence('preprocess', options.distPreprocess, 'copy', callback);
       } else {
@@ -42,8 +43,8 @@ export function distTasks (gulp, opts) {
       __dirname, 'webpack.dist.config.js'
     );
 
-    if (argv.config) {
-      webpackConfigPath = path.resolve(argv.config);
+    if (options.argv.config) {
+      webpackConfigPath = path.resolve(options.argv.config);
     }
 
     const config = require(webpackConfigPath);

--- a/src/webpack.dist.config.js
+++ b/src/webpack.dist.config.js
@@ -2,9 +2,7 @@ require('babel-register');
 
 import webpack from 'webpack';
 import deepAssign from 'deep-assign';
-import yargs from 'yargs';
 import unique from './utils/unique';
-const argv = yargs.argv;
 
 import gulpOptionsBuilder from './gulp-options-builder';
 const options = gulpOptionsBuilder();
@@ -22,7 +20,7 @@ config.plugins = [
   new webpack.optimize.OccurenceOrderPlugin()
 ];
 
-if (!argv.skipMinify) {
+if (options.argv.minify) {
   config.plugins.push(new webpack.optimize.UglifyJsPlugin({
     compress: {
       warnings: false


### PR DESCRIPTION
* Args are now configurable in options builder using yargs
* `skip-` args are deprecated in favor of using yarg's `--no-` switches
* CLI args are now apart of options so that an arg can be set by default
  in grommet config file.
* These defaults can still be overwritten with args.