### PR TITLE
Changed the name of the tgz archive file generated by the pack tool

### DIFF
--- a/src/gulp-tasks-pack.js
+++ b/src/gulp-tasks-pack.js
@@ -36,6 +36,14 @@ export function packTasks (gulp) {
           if (err) {
             throw err;
           }
+
+          const newTarballName = `${json.name}-${json.version}-src-with-dependencies.tgz`;
+          fs.renameSync(
+            path.resolve(tarballName),
+            path.resolve(newTarballName)
+          );
+          console.log("Changed archive name to", newTarballName);
+
           const dependencies = fs.readdirSync('./tmp/package/node_modules');
 
           dependencies.forEach((dependency) => {


### PR DESCRIPTION
It now includes 'src-with-dependencies'. This distinguishes it from the other archive files that are included in a release. This archive file is needed for OSRB reviews for grommet v1.x.